### PR TITLE
Fixes

### DIFF
--- a/scripts/battle/enemies/fmarcy_first.lua
+++ b/scripts/battle/enemies/fmarcy_first.lua
@@ -23,6 +23,7 @@ function Marcy:init()
 
     -- Mercy given when sparing this enemy before its spareable (20% for basic enemies)
     self.spare_points = 0
+    self.tired_percentage = 0
     self.service_mercy = 0
 
     -- List of possible wave ids, randomly picked each turn

--- a/scripts/world/cutscenes/cliffs.lua
+++ b/scripts/world/cutscenes/cliffs.lua
@@ -1077,7 +1077,7 @@ return {
 		cutscene:text("* The three of you explain what happened.")
 		
 		-- 1160, 240
-		local lore_board = Registry.createEvent("lore_board", {x = 1160, y = 240, properties = {}})
+		local lore_board = Registry.createLegacyEvent("lore_board", {x = 1160, y = 240, properties = {}})
 		Game.world:spawnObject(lore_board)
 		
 		jamm.x = 1300


### PR DESCRIPTION
* Fixed a crash when trying to spawn an event the old way after the first Marcy fight
* Fixed the Tired message appearing for Marcy upon getting hit